### PR TITLE
Signal Paths: crossovers, and strips that insert instead of publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and commit log.
 
 ---
 
-## [v0.5.1](https://github.com/knightinfected/PipeWireController/releases/tag/v0.5.1) — 2026-08-16
+## Unreleased
 
 **Crossovers — send each band of the audio to a destination of its own**
 
@@ -79,6 +79,14 @@ picker, because nobody can usefully select one. Signal Paths still shows them
 — it draws the strips themselves, with their volume and level meter.
 “Equalize everything” and “Subwoofer and satellites” are both built this way
 now, so neither adds anything to your device list.
+
+Inserting needs **WirePlumber 0.5 or later**. Where it is older — Ubuntu 24.04
+LTS ships 0.4.17 — strips publish their own output as they always did, and the
+mode is not offered.
+
+---
+
+## [v0.5.1](https://github.com/knightinfected/PipeWireController/releases/tag/v0.5.1) — 2026-08-16
 
 **App Policy bug fixes and additions- rules now have a direction, plus snapshot
 updates and a launch fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,63 @@ and commit log.
 
 ---
 
+## Unreleased
+
+**Crossovers — send each band of the audio to a destination of its own**
+
+A **crossover** is a new kind of object on the Signal Paths board, and it sits
+where it belongs: between what plays and what it comes out of. It stands in
+front of an output, so apps keep playing exactly where they always played, and
+it hands each band of that audio to the destinations you choose.
+
+The card is a table. One row per band, and each row says two things:
+
+| band | goes to |
+|---|---|
+| 80 Hz and below | Internal audio |
+| 80 Hz – 2 kHz | Focusrite Scarlett 2i2 |
+| 2 kHz and above | Internal audio |
+
+Add a band, drag its edges, give it as many destinations as you like. Two
+bands naming the same destination are summed. Bands use Linkwitz-Riley filters
+at 12, 24 or 48 dB/oct, so two bands meeting at one frequency add back up flat
+— and each one carries its own level, delay and polarity, because drivers are
+rarely the same distance away or wired the same way round.
+
+**Your inputs and outputs are untouched.** The crossover publishes nothing
+selectable: it attaches to the output as a `filter.smart` insert and reaches
+its other destinations through capture streams. Nothing new appears in the
+sound settings, and no app has to be repointed. One crossover is one unit,
+whatever the number of bands.
+
+The **“Subwoofer and satellites”** recipe builds a two-band crossover in one
+click. For a single card that carries the bands on different channels — a 2.1
+or 5.1 output — the **Crossover stage** and the **“Bass management”** template
+do that inside one strip instead.
+
+**Strips insert themselves into an output instead of becoming one**
+
+A strip used to publish a sink, which meant every equalizer and every
+crossover added entries to the sound settings and asked you to go and select
+one of them. A strip now has a **mode**:
+
+- **inside the output** (the new default): it attaches to a device as a
+  `filter.smart` insert. WirePlumber routes everything heading for that device
+  through the strip first. Your inputs and outputs are untouched, nothing new
+  appears anywhere, and no app is repointed.
+- **its own output**: the previous behaviour, kept for the case that needs it
+  — a bus something else has to *choose*, like the capture sink OBS records
+  from. A mix that a source strip sends to falls back to this automatically.
+- **a copy of another strip**: a capture stream, not a sink. It is how one
+  band of a crossover reaches a *second* card without an output being
+  published to carry it.
+
+Inserts are hidden from the Devices page, the dashboard and every target
+picker, because nobody can usefully select one. Signal Paths still shows them
+— it draws the strips themselves, with their volume and level meter.
+“Equalize everything” and “Subwoofer and satellites” are both built this way
+now, so neither adds anything to your device list.
+
 ## [v0.5.0](https://github.com/knightinfected/PipeWireController/releases/tag/v0.5.0) — 2026-08-10
 
 **Renamed the package, the command and the desktop entry — the app is still

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Ubuntu/Debian and others below).
 Everything under PipeWire's *Configuration* documentation — clock/quantum
 tuning, stream processing, session policy, filter chains, HRIR virtual
 surround — exposed as toggles and dropdowns, plus **Signal Paths** for building
-the route your audio actually takes ([new in v0.4.0](#new-in-v040)), **live
+the route your audio actually takes ([new in v0.4.0](#new-in-v040)) with
+**crossovers** that split the audio by frequency and send each band to its own
+speakers, **live
 level meters** on every volume control, a parametric **equalizer** and
 **microphone cleanup** ([new in v0.3.6](#new-in-v036)), a live **patchbay**,
 performance **monitoring**, **virtual devices**, routing snapshots,

--- a/pwctl/backend/chains.py
+++ b/pwctl/backend/chains.py
@@ -271,11 +271,15 @@ def pick_targets(node_name: str, sinks: list, edges: dict[str, str]) -> list:
     """The sinks `node_name` may feed, in the order given.
 
     Other managed sinks stay in the list — chaining them is the point.  What
-    is dropped is this object itself and any target whose own chain leads back
-    here.  Pass an empty `node_name` for an object that does not exist yet.
+    is dropped is this object itself, any target whose own chain leads back
+    here, and any smart-filter insert: an insert is not a destination but a
+    stage in one, and pointing at it would put audio into a device's path
+    behind that device's back.  Pass an empty `node_name` for an object that
+    does not exist yet.
     """
     return [n for n in sinks
             if n.name != node_name
+            and not getattr(n, 'is_insert', False)
             and not would_loop(node_name, n.name, edges)]
 
 

--- a/pwctl/backend/path_templates.py
+++ b/pwctl/backend/path_templates.py
@@ -31,7 +31,7 @@ where the second half starts for the empty-state board, and is not a category.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from . import paths
 
@@ -88,14 +88,15 @@ def find_plugin(installed, patterns):
 class Step:
     """One stage a template wants, before it is matched against this machine.
 
-    An `eq` step is always buildable; an `effect` step is a wish, and
-    `patterns` is how it is granted.
+    An `eq` or `xover` step is always buildable; an `effect` step is a wish,
+    and `patterns` is how it is granted.
     """
-    kind: str                      # 'eq' | 'effect'
+    kind: str                      # 'eq' | 'xover' | 'effect'
     name: str
     preamp: float = 0.0
     bands: tuple = ()              # (type, freq, gain, q)
     patterns: tuple = ()           # effect only, most specific first
+    params: dict = field(default_factory=dict)   # xover only, see paths
 
 
 @dataclass
@@ -107,6 +108,7 @@ class Template:
     role: str                      # the strip it builds: 'source' | 'mix'
     kind: str = 'app'              # source flavour, see paths.SOURCE_KINDS
     positions: tuple = ('FL', 'FR')
+    out_positions: tuple = ()      # set only when a band leaves on its own lane
     advanced: bool = False
     steps: tuple = ()
     detail: str = ''               # the longer line, shown in the dialog
@@ -134,6 +136,9 @@ def build_stages(template: Template, installed) -> tuple[list, list]:
     for step in template.steps:
         if step.kind == 'eq':
             stages.append(_eq_stage(step))
+            continue
+        if step.kind == 'xover':
+            stages.append(paths.new_stage('xover', step.name, **step.params))
             continue
         hit = find_plugin(installed, step.patterns)
         if hit is None:
@@ -320,6 +325,23 @@ CATALOG: list = [
         steps=(Step('effect', 'Crossfeed', patterns=P_CROSSFEED),
                Step('eq', 'Tilt back', preamp=-1.0, bands=(
                    ('HSC', 8000, 1.0, 0.7),)))),
+    Template(
+        id='bass-management', title='Bass management', role='mix',
+        advanced=True, icon='view-list-symbolic',
+        positions=('FL', 'FR'), out_positions=('FL', 'FR', 'LFE'),
+        blurb='Takes the bass off your speakers and gives it to the sub.',
+        detail='A stereo mix that comes out as 2.1: everything under 80 Hz is '
+               'summed to mono and sent to the subwoofer lane, everything '
+               'above it stays on the front pair. Point this at a card with a '
+               'subwoofer output — or at a 5.1 profile — and the two bands '
+               'arrive on separate speakers. Both cross at the same frequency '
+               'with the same slope, so they add back up flat.',
+        steps=(Step('xover', 'Low band to sub',
+                    params={'mode': 'lowpass', 'freq': 80.0,
+                            'channels': ['FL', 'FR'], 'route': ['LFE']}),
+               Step('xover', 'High band to fronts',
+                    params={'mode': 'highpass', 'freq': 80.0,
+                            'channels': ['FL', 'FR']}))),
     Template(
         id='small-speakers', title='Small speakers', role='mix',
         advanced=True, icon='computer-symbolic',

--- a/pwctl/backend/paths.py
+++ b/pwctl/backend/paths.py
@@ -253,9 +253,15 @@ def list_strips() -> list[Strip]:
     for f in sorted(PATH_DIR.glob('*.json')):
         try:
             data = json.loads(f.read_text())
-            out.append(Strip(**{k: v for k, v in data.items() if k in known}))
+            strip = Strip(**{k: v for k, v in data.items() if k in known})
         except (ValueError, TypeError):
             continue
+        # Also on the way in, so a crossover written before the rows were
+        # ordered reads back in spectrum order instead of waiting for its
+        # next edit to straighten itself out.
+        if strip.role == 'xover':
+            sort_bands(strip)
+        out.append(strip)
     out.sort(key=lambda s: s.order)
     return out
 
@@ -275,8 +281,27 @@ def mixes(strips=None) -> list[Strip]:
             if s.role == 'mix']
 
 
+def sort_bands(strip: Strip):
+    """Put the rows in the order the spectrum runs, lowest band first.
+
+    A crossover is read as a picture of the spectrum, so the rows have to
+    follow it: a band added later but sitting between two existing ones
+    belongs between them, not at the bottom of the list.  Sorting on save
+    rather than only on screen means the stored file, the generated config
+    and the card all agree.
+
+    An edge of 0 means "no limit on that side", so it is the bottom of the
+    range when it is the low edge and the top of it when it is the high one —
+    which is why the high edge cannot simply be compared as a number.
+    """
+    strip.bands.sort(key=lambda b: (float(b.get('lo') or 0.0),
+                                    float(b.get('hi') or 0.0) or float('inf')))
+
+
 def save_meta(strip: Strip):
     ensure_dirs()
+    if strip.role == 'xover':
+        sort_bands(strip)
     system.atomic_write(strip.meta_path, json.dumps(asdict(strip), indent=2))
 
 
@@ -1029,7 +1054,7 @@ def output_targets(strip: Strip, sinks: list, edges: dict | None = None) -> list
 __all__ = [
     'Strip', 'ROLES', 'MODES', 'insertable', 'SOURCE_KINDS', 'STAGE_KINDS',
     'BAND_FILTERS',
-    'XOVER_MODES', 'XOVER_SLOPES', 'DEFAULT_SLOPE',
+    'XOVER_MODES', 'XOVER_SLOPES', 'DEFAULT_SLOPE', 'sort_bands',
     'PATH_DIR', 'list_strips', 'sources', 'mixes', 'save_meta', 'new_strip',
     'new_stage', 'clone_stage', 'build_graph', 'generate', 'resolve_target',
     'sync_fan', 'apply', 'set_enabled', 'status', 'delete', 'target_edges',

--- a/pwctl/backend/paths.py
+++ b/pwctl/backend/paths.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 from .. import spa_json
-from . import system, virtual
+from . import pw, system, virtual
 from .chains import GEN_DIR, ensure_unit, pick_targets, would_loop
 from .config import XDG_CONFIG
 
@@ -338,6 +338,13 @@ def insertable(strip: Strip, strips=None) -> bool:
     the name has to keep meaning something selectable.
     """
     if strip.mode == 'tap' or not strip.can_insert():
+        return False
+    # An insert is a `filter.smart` one, and that is WirePlumber 0.5 and later.
+    # On 0.4 the pair is still built but never attaches to its target: the
+    # strip does nothing at all while the app claims it is in the path, which
+    # is the kind of silence nobody thinks to go looking for.  Publish a sink
+    # there instead — audible, selectable, and what the strip did before.
+    if not pw.smart_filters_supported():
         return False
     if strip.role == 'mix':
         others = strips if strips is not None else list_strips()

--- a/pwctl/backend/paths.py
+++ b/pwctl/backend/paths.py
@@ -25,7 +25,10 @@ Channels are declared once, on the strip.  The graph is built as explicit
 per-channel lanes rather than relying on PipeWire's "duplicate the graph to
 match the channel count" shortcut, because that shortcut only works when every
 stage has the same port count — mixing a mono equalizer with a stereo plugin
-breaks it.  Lanes also leave room for per-stage channel rules later.
+breaks it.  Lanes are also what makes a **crossover** stage possible: it reads
+some lanes and writes others, so a strip can take stereo in and put the low
+band on lanes of its own.  A strip that does that declares `out_positions`,
+and then its sink and its playback stream no longer have the same layout.
 
 Rings are impossible between a source and a mix (a mix only ever outputs to a
 device), but a mix output is a name the user picked, so it is still checked
@@ -48,13 +51,78 @@ from .config import XDG_CONFIG
 
 PATH_DIR = XDG_CONFIG / 'pipewire-controller' / 'paths'
 
-ROLES = ('source', 'mix')
+ROLES = ('source', 'mix', 'xover')
+
+# A crossover is not a stage inside one strip but a thing of its own, sitting
+# between what plays and what it comes out of.  It has to be, because its
+# whole job is to send *different frequencies to different destinations*: as a
+# stage it could only ever filter the one path it was standing in, so a
+# two-way split meant building the path twice and keeping the two halves in
+# step by hand.
+#
+# One crossover owns a list of bands.  A band is a frequency range and the
+# destinations that range is played on.  Two bands can name the same
+# destination (they are summed) and one band can name several.
+#
+# It generates a single unit holding one filter-chain per destination: the
+# destination it is inserted into is served by the insert itself, and every
+# other destination by a tap reading the insert's input.  That keeps the
+# endpoints exactly as they were — the crossover is intermediate, never a
+# replacement for either end.
+DEFAULT_BAND_SLOPE = 24
+
+# How a strip shows itself to the rest of the session.
+#
+#   sink    it publishes a selectable output of its own, and audio reaches it
+#           because something was pointed at it.  The original model, and
+#           still the right one for a bus other apps have to *choose* — the
+#           capture sink OBS records from.
+#
+#   insert  it publishes nothing selectable and attaches itself to a device
+#           instead: WirePlumber links every stream heading for that device
+#           through the strip first (`filter.smart`).  The device stays the
+#           output everyone selects, so nothing new appears in anyone's list
+#           and no app has to be repointed.
+#
+#   tap     it takes a copy of what another strip is being fed and plays that
+#           somewhere else.  A capture stream and a playback stream, neither
+#           of them a sink — the only way to get one band of a crossover onto
+#           a *second* card without publishing an output to carry it.
+#
+# `sink` is the dataclass default so that strips written before this existed
+# keep the behaviour they were built with; `new_strip` prefers `insert`.
+MODES = ('sink', 'insert', 'tap')
 SOURCE_KINDS = {
     'app': 'An application',
     'mic': 'A microphone',
     'everything': 'Everything (this strip becomes the default output)',
 }
-STAGE_KINDS = ('eq', 'effect', 'convolver')
+STAGE_KINDS = ('eq', 'effect', 'convolver', 'xover')
+
+# Crossover bands.  A band is a filter *and* a route: which lanes it listens
+# to and which lanes it comes out on.  Leaving the route empty filters in
+# place, which is what a plain "cut everything under 80 Hz" wants; setting it
+# is what splits one input into several speaker feeds.
+XOVER_MODES = {
+    'lowpass': 'Low band (everything below the crossover)',
+    'highpass': 'High band (everything above the crossover)',
+    'bandpass': 'Middle band (between the two crossovers)',
+}
+
+# Linkwitz-Riley slopes, as the Q of each cascaded biquad section.  LR is the
+# crossover filter: two complementary LR bands sum back to a flat response,
+# which Butterworth sections on their own do not.  LR2 is one critically
+# damped section, LR4 two Butterworth ones, LR8 a cascade of two 4th-order
+# Butterworths.
+XOVER_SLOPES = {
+    12: (0.5,),
+    24: (0.7071, 0.7071),
+    48: (0.5412, 1.3066, 0.5412, 1.3066),
+}
+DEFAULT_SLOPE = 24
+# Delay headroom compiled into a band's delay node; the control can be moved
+# at runtime, the buffer size cannot.
+MAX_DELAY_S = 0.2
 
 # AutoEQ/APO band types -> the builtin biquad that implements them.  Biquad
 # control ports (Freq/Q/Gain) can be written at runtime, which a param_eq
@@ -73,9 +141,15 @@ DEFAULT_POSITIONS = ['FL', 'FR']
 class Strip:
     id: str
     name: str
-    role: str = 'source'                      # 'source' | 'mix'
+    role: str = 'source'                      # see ROLES
     kind: str = 'app'                         # sources only, see SOURCE_KINDS
+    bands: list = field(default_factory=list)  # xover only, see new_band
+    insert_into: str = ''                     # xover: device it sits in front
+    #                                           of; '' follows the default
+    mode: str = 'sink'                        # see MODES
+    tap_source: str = ''                      # tap mode: node.name to copy
     positions: list = field(default_factory=lambda: list(DEFAULT_POSITIONS))
+    out_positions: list = field(default_factory=list)  # empty: same as above
     stages: list = field(default_factory=list)     # stage dicts, see _stage_*
     sends: list = field(default_factory=list)      # source -> mix ids
     outputs: list = field(default_factory=list)    # mix -> device node.names
@@ -101,6 +175,15 @@ class Strip:
         return PATH_DIR / f'{self.id}.json'
 
     @property
+    def link_group(self) -> str:
+        """Ties the capture and playback halves together as one filter.
+
+        WirePlumber needs this to see the two nodes as a single object it can
+        splice into a link, rather than as a sink and an unrelated stream.
+        """
+        return f'pwctl-{self.id}'
+
+    @property
     def fan_id(self) -> str:
         """Id of the combine device built when this strip feeds several."""
         return f'{self.id}-fan'
@@ -109,8 +192,40 @@ class Strip:
     def channels(self) -> int:
         return len(self.positions)
 
+    @property
+    def out_layout(self) -> list:
+        """What comes out.  Wider than `positions` once a band is routed to
+        lanes of its own — a stereo sink feeding a bi-amped 4-way output."""
+        return list(self.out_positions or self.positions)
+
+    @property
+    def out_channels(self) -> int:
+        return len(self.out_layout)
+
     def active_stages(self) -> list[dict]:
         return [s for s in self.stages if not s.get('bypass')]
+
+    def insert_device(self) -> str:
+        """The device an inserted strip attaches to; '' means follow default.
+
+        A smart filter with no target follows whatever the default output is,
+        which is exactly what "everything, corrected" means — and it keeps
+        following it when the user changes their output.
+        """
+        return self.outputs[0] if self.outputs else ''
+
+    def can_insert(self) -> bool:
+        """Whether this strip could attach itself to a device.
+
+        Inserting means becoming part of one device's path, so it needs a
+        single destination and no second life as a sink other things were
+        pointed at: a mix feeding two devices has to fan out through a sink,
+        and a source capturing one app has to be a sink for that app to play
+        into.
+        """
+        if self.role == 'mix':
+            return len(self.outputs) <= 1
+        return self.kind == 'everything' and not self.sends
 
 
 # ------------------------------------------------------------------ store --
@@ -150,6 +265,11 @@ def sources(strips=None) -> list[Strip]:
             if s.role == 'source']
 
 
+def crossovers(strips=None) -> list[Strip]:
+    return [s for s in (strips if strips is not None else list_strips())
+            if s.role == 'xover']
+
+
 def mixes(strips=None) -> list[Strip]:
     return [s for s in (strips if strips is not None else list_strips())
             if s.role == 'mix']
@@ -172,15 +292,92 @@ def new_strip(name: str, role: str, **kw) -> Strip:
     # A new strip belongs at the bottom of its column, not the top.
     kw.setdefault('order', max((s.order for s in existing if s.role == role),
                                default=-1) + 1)
-    return Strip(id=sid, name=name, role=role, **kw)
+    if role == 'xover' and 'bands' not in kw:
+        # A crossover with no bands splits nothing.  Two bands meeting at
+        # 80 Hz is the split almost everyone wants first, and both rows are
+        # visible straight away — the destinations are the only blanks left.
+        kw['bands'] = [new_band('Low', hi=80.0), new_band('High', lo=80.0)]
+    strip = Strip(id=sid, name=name, role=role, **kw)
+    # Insert wherever it is possible: a new strip should disappear into the
+    # path it is correcting rather than turn up as one more thing to choose.
+    if 'mode' not in kw and insertable(strip, existing):
+        strip.mode = 'insert'
+    return strip
+
+
+def insertable(strip: Strip, strips=None) -> bool:
+    """Whether `strip` may attach itself to a device instead of publishing.
+
+    On top of the shape the strip itself knows about, a mix something *sends*
+    to has to stay a sink: a send is an explicit link to a named node, and
+    the name has to keep meaning something selectable.
+    """
+    if strip.mode == 'tap' or not strip.can_insert():
+        return False
+    if strip.role == 'mix':
+        others = strips if strips is not None else list_strips()
+        if any(strip.id in s.sends for s in others if s.role == 'source'):
+            return False
+    return True
 
 
 def new_stage(kind: str, name: str = '', **params) -> dict:
     """A stage dict.  Kept as plain data so it round-trips through JSON."""
     if kind not in STAGE_KINDS:
         raise ValueError(f'unknown stage kind {kind!r}')
+    if kind == 'xover':
+        # A fresh band has to be buildable before it is edited, so it starts
+        # as a plain 80 Hz low band across the whole strip.
+        params = {'mode': 'lowpass', 'freq': 80.0, 'freq_hi': 2000.0,
+                  'slope': DEFAULT_SLOPE, 'gain': 0.0, 'delay': 0.0,
+                  'invert': False, 'channels': [], 'route': [], **params}
     return {'id': uuid.uuid4().hex[:8], 'kind': kind,
             'name': name or kind, 'bypass': False, 'params': dict(params)}
+
+
+def new_band(name: str = '', lo: float = 0.0, hi: float = 0.0,
+             outputs=None, **kw) -> dict:
+    """One band of a crossover: a frequency range and where it is played.
+
+    `lo` and `hi` are the edges in Hz.  Zero means "no edge on that side", so
+    a subwoofer band is 0 - 80 and the band above it is 80 - 0; that way a
+    two-way split reads as two rows that meet at one number, and nothing has
+    to know about "lowpass" and "highpass" as separate ideas.
+    """
+    return {'id': uuid.uuid4().hex[:8], 'name': name or 'Band',
+            'lo': float(lo), 'hi': float(hi),
+            'slope': int(kw.get('slope', DEFAULT_BAND_SLOPE)),
+            'gain': float(kw.get('gain', 0.0)),
+            'delay': float(kw.get('delay', 0.0)),
+            'invert': bool(kw.get('invert', False)),
+            'mute': bool(kw.get('mute', False)),
+            'outputs': list(outputs or [])}
+
+
+def band_label(band: dict) -> str:
+    """The range as a person would say it — '80 Hz and below', '80 Hz - 2 kHz'."""
+    def hz(v):
+        return f'{v / 1000:g} kHz' if v >= 1000 else f'{v:g} Hz'
+    lo, hi = float(band.get('lo') or 0), float(band.get('hi') or 0)
+    if lo and hi:
+        return f'{hz(lo)} - {hz(hi)}'
+    if hi:
+        return f'{hz(hi)} and below'
+    if lo:
+        return f'{hz(lo)} and above'
+    return 'Everything'
+
+
+def band_destinations(strip: Strip) -> list[str]:
+    """Every destination this crossover feeds, in the order bands name them."""
+    out: list[str] = []
+    for band in strip.bands:
+        if band.get('mute'):
+            continue
+        for dev in band.get('outputs') or []:
+            if dev not in out:
+                out.append(dev)
+    return out
 
 
 def clone_stage(stage: dict, rename: bool = True) -> dict:
@@ -311,48 +508,219 @@ def _convolver_lane(stage: dict, tag: str, chan: int, nodes: list,
     return f'{name}:In', f'{name}:Out'
 
 
+def _xover_sections(params: dict) -> list[tuple[str, float, float]]:
+    """The biquad sections one band is made of, as (label, freq, Q)."""
+    mode = str(params.get('mode') or 'lowpass')
+    if mode not in XOVER_MODES:
+        raise ValueError(f'unknown crossover mode {mode!r}')
+    slope = int(params.get('slope') or DEFAULT_SLOPE)
+    qs = XOVER_SLOPES.get(slope)
+    if qs is None:
+        raise ValueError(f'unknown crossover slope {slope}')
+    lo = float(params.get('freq') or 80.0)
+    if mode == 'lowpass':
+        return [('bq_lowpass', lo, q) for q in qs]
+    if mode == 'highpass':
+        return [('bq_highpass', lo, q) for q in qs]
+    hi = float(params.get('freq_hi') or 0.0)
+    if hi <= lo:
+        raise ValueError('the upper crossover has to sit above the lower one')
+    return ([('bq_highpass', lo, q) for q in qs]
+            + [('bq_lowpass', hi, q) for q in qs])
+
+
+def _xover_lane(stage: dict, tag: str, nodes: list,
+                links: list) -> tuple[str, str]:
+    """One copy of a band: its filter cascade, then delay and trim.
+
+    Delay and polarity are here because a crossover is only half a filter
+    problem — the other half is that the drivers it feeds are rarely the same
+    distance away or wired the same way round.
+    """
+    p = stage.get('params') or {}
+    chain: list[str] = []
+    for i, (label, freq, q) in enumerate(_xover_sections(p)):
+        chain.append(_node(nodes, f'{tag}f{i}', 'builtin', label,
+                           control={'Freq': freq, 'Q': q}))
+    delay_s = float(p.get('delay') or 0.0) / 1000.0
+    if delay_s > 0:
+        chain.append(_node(nodes, f'{tag}dly', 'builtin', 'delay',
+                           config={'max-delay': MAX_DELAY_S},
+                           control={'Delay (s)': min(delay_s, MAX_DELAY_S)}))
+    mult = _preamp_mult(p.get('gain') or 0.0)
+    if p.get('invert'):
+        mult = -mult
+    if abs(mult - 1.0) > 1e-9:
+        chain.append(_node(nodes, f'{tag}trim', 'builtin', 'linear',
+                           control={'Mult': round(mult, 6), 'Add': 0.0}))
+    if not chain:
+        chain.append(_node(nodes, f'{tag}thru', 'builtin', 'copy'))
+    for a, b in zip(chain, chain[1:]):
+        links.append({'output': f'{a}:Out', 'input': f'{b}:In'})
+    return f'{chain[0]}:In', f'{chain[-1]}:Out'
+
+
+def _lanes_for(names, layout: list, fallback) -> list[int]:
+    """Position names -> lane indices, ignoring what this layout hasn't got.
+
+    A strip re-laid out from 5.1 to stereo keeps its stages; the bands that
+    named a lane which no longer exists fall back to the whole strip rather
+    than refusing to build.
+    """
+    idx = [layout.index(n) for n in names if n in layout]
+    return idx or list(fallback)
+
+
+def _apply_xover(stage: dict, tag: str, strip: Strip, cur: list,
+                 nodes: list, links: list):
+    """Filter some lanes into some lanes, in place unless routed elsewhere."""
+    p = stage.get('params') or {}
+    layout = strip.out_layout
+    read = _lanes_for(p.get('channels') or [], layout, range(len(cur)))
+    dest = _lanes_for(p.get('route') or [], layout, read)
+    # Read every source port before writing any of them: a band that swaps
+    # two lanes over would otherwise pick up its own output halfway through.
+    taps = [cur[c] for c in read]
+
+    if len(dest) == 1 and len(taps) > 1:
+        # Several lanes into one — the mono feed a single subwoofer wants.
+        gain = round(1.0 / len(taps), 4)
+        mix = _node(nodes, f'{tag}sum', 'builtin', 'mixer',
+                    control={f'Gain {i + 1}': gain
+                             for i in range(len(taps))})
+        for i, port in enumerate(taps):
+            links.append({'output': port, 'input': f'{mix}:In {i + 1}'})
+        taps = [f'{mix}:Out']
+
+    for i, lane in enumerate(dest):
+        pin, pout = _xover_lane(stage, f'{tag}d{i}', nodes, links)
+        links.append({'output': taps[i % len(taps)], 'input': pin})
+        cur[lane] = pout
+
+
+def _band_lane(band: dict, tag: str, nodes: list,
+               links: list) -> tuple[str, str]:
+    """One channel of one band: the range, then its level, delay and polarity.
+
+    Linkwitz-Riley sections, so that two bands meeting at one frequency add
+    back up flat instead of dipping or bulging where they cross.
+    """
+    qs = XOVER_SLOPES.get(int(band.get('slope') or DEFAULT_BAND_SLOPE)) \
+        or XOVER_SLOPES[DEFAULT_BAND_SLOPE]
+    lo, hi = float(band.get('lo') or 0), float(band.get('hi') or 0)
+    if lo and hi and hi <= lo:
+        raise ValueError(f"{band.get('name') or 'band'}: the top of the band "
+                         'has to sit above the bottom')
+    chain: list[str] = []
+    for i, q in enumerate(qs if lo else ()):
+        chain.append(_node(nodes, f'{tag}hp{i}', 'builtin', 'bq_highpass',
+                           control={'Freq': lo, 'Q': q}))
+    for i, q in enumerate(qs if hi else ()):
+        chain.append(_node(nodes, f'{tag}lp{i}', 'builtin', 'bq_lowpass',
+                           control={'Freq': hi, 'Q': q}))
+    delay_s = float(band.get('delay') or 0.0) / 1000.0
+    if delay_s > 0:
+        chain.append(_node(nodes, f'{tag}dly', 'builtin', 'delay',
+                           config={'max-delay': MAX_DELAY_S},
+                           control={'Delay (s)': min(delay_s, MAX_DELAY_S)}))
+    mult = _preamp_mult(band.get('gain') or 0.0)
+    if band.get('invert'):
+        mult = -mult
+    if abs(mult - 1.0) > 1e-9:
+        chain.append(_node(nodes, f'{tag}trim', 'builtin', 'linear',
+                           control={'Mult': round(mult, 6), 'Add': 0.0}))
+    if not chain:
+        chain.append(_node(nodes, f'{tag}thru', 'builtin', 'copy'))
+    for a, b in zip(chain, chain[1:]):
+        links.append({'output': f'{a}:Out', 'input': f'{b}:In'})
+    return f'{chain[0]}:In', f'{chain[-1]}:Out'
+
+
+def build_dest_graph(strip: Strip, dest: str) -> dict:
+    """The graph feeding one destination: every band that names it, summed.
+
+    A destination no band names still needs a graph — it is the input side of
+    the crossover and has to carry audio to the taps — so it gets silence
+    rather than nothing, and the device simply plays nothing.
+    """
+    channels = strip.channels
+    nodes: list = []
+    links: list = []
+    entry = [f'{_node(nodes, f"in{c}", "builtin", "copy")}:In'
+             for c in range(channels)]
+    bands = [b for b in strip.bands
+             if not b.get('mute') and dest in (b.get('outputs') or [])]
+
+    outs: list[str] = []
+    for c in range(channels):
+        taps = []
+        for bi, band in enumerate(bands):
+            pin, pout = _band_lane(band, f'b{bi}c{c}', nodes, links)
+            links.append({'output': f'in{c}:Out', 'input': pin})
+            taps.append(pout)
+        if not taps:
+            # Nothing routed here: hold the lane at silence.
+            name = _node(nodes, f'mute{c}', 'builtin', 'linear',
+                         control={'Mult': 0.0, 'Add': 0.0})
+            links.append({'output': f'in{c}:Out', 'input': f'{name}:In'})
+            outs.append(f'{name}:Out')
+        elif len(taps) == 1:
+            outs.append(taps[0])
+        else:
+            mix = _node(nodes, f'sum{c}', 'builtin', 'mixer',
+                        control={f'Gain {i + 1}': 1.0
+                                 for i in range(len(taps))})
+            for i, port in enumerate(taps):
+                links.append({'output': port, 'input': f'{mix}:In {i + 1}'})
+            outs.append(f'{mix}:Out')
+
+    return {'nodes': nodes, 'links': links, 'inputs': entry, 'outputs': outs}
+
+
 def build_graph(strip: Strip) -> dict:
     """The fused `filter.graph` for every enabled stage on this strip."""
     channels = strip.channels
-    if channels < 1:
+    width = strip.out_channels
+    if channels < 1 or width < 1:
         raise ValueError('a strip needs at least one channel')
     nodes: list = []
     links: list = []
-    entry: list = [None] * channels     # port the graph takes audio in on
-    cur: list = [None] * channels       # port currently carrying each channel
+
+    # A copy per capture channel, because a graph input port can be named
+    # only once and a crossover reading the same channel into two different
+    # bands needs it twice.  It also gives every lane something to carry when
+    # the strip has no stages at all.
+    entry = [f'{_node(nodes, f"in{c}", "builtin", "copy")}:In'
+             for c in range(channels)]
+    # Output lanes start on the capture channel of the same index; a strip
+    # that outputs wider than it captures repeats the layout, so the extra
+    # lanes carry a copy of the front until a band is routed onto them.
+    cur: list = [f'in{c % channels}:Out' for c in range(width)]
 
     for si, stage in enumerate(strip.active_stages()):
         tag = f's{si}'
         kind = stage.get('kind')
+        if kind == 'xover':
+            _apply_xover(stage, tag, strip, cur, nodes, links)
+            continue
         if kind == 'eq':
             lanes = [_eq_lane(stage, tag, c, nodes, links)
-                     for c in range(channels)]
+                     for c in range(width)]
             ins = [a for a, _ in lanes]
             outs = [b for _, b in lanes]
         elif kind == 'convolver':
             lanes = [_convolver_lane(stage, tag, c, nodes, links)
-                     for c in range(channels)]
+                     for c in range(width)]
             ins = [a for a, _ in lanes]
             outs = [b for _, b in lanes]
         elif kind == 'effect':
-            ins, outs = _effect_lanes(stage, tag, channels, nodes, links)
+            ins, outs = _effect_lanes(stage, tag, width, nodes, links)
         else:
             raise ValueError(f'unknown stage kind {kind!r}')
 
-        for c in range(channels):
-            if cur[c] is None:
-                entry[c] = ins[c]
-            else:
-                links.append({'output': cur[c], 'input': ins[c]})
+        for c in range(width):
+            links.append({'output': cur[c], 'input': ins[c]})
             cur[c] = outs[c]
-
-    # Channels no stage touched — and the no-stages-at-all case — still have
-    # to reach the other side, so give them a passthrough.
-    for c in range(channels):
-        if cur[c] is None:
-            name = _node(nodes, f'thru{c}', 'builtin', 'copy')
-            entry[c] = f'{name}:In'
-            cur[c] = f'{name}:Out'
 
     return {'nodes': nodes, 'links': links,
             'inputs': entry, 'outputs': cur}
@@ -399,10 +767,86 @@ def resolve_target(strip: Strip, strips=None) -> str:
     return f'pwctl.{strip.fan_id}'
 
 
+def _xover_conf(strip: Strip) -> dict:
+    """One unit, one filter-chain per destination.
+
+    The first module is the crossover itself: a smart-filter insert on the
+    device audio was already going to, so sources keep playing where they
+    always played and nothing new appears to be selected.  Its own graph
+    carries whatever bands were routed back to that device.
+
+    Every other destination is a tap: it reads the insert's *input* — the
+    monitor of its sink, which is the signal before any band was applied —
+    filters its own bands out of it and plays them on its own device.  A tap
+    rather than a second sink, because a sink here would be an output nobody
+    should ever pick, and it would come back to haunt the device list.
+    """
+    dests = band_destinations(strip)
+    host = strip.insert_into
+    # The insert's device is served by the insert.  With no device named, the
+    # crossover follows the default output and the first destination is a tap
+    # like all the others.
+    modules = []
+
+    insert_graph = build_dest_graph(strip, host) if host else \
+        build_dest_graph(strip, '\0none')
+    modules.append({
+        'name': 'libpipewire-module-filter-chain',
+        'args': {
+            'node.description': strip.name,
+            'filter.graph': insert_graph,
+            'capture.props': {
+                'node.name': strip.node_name,
+                'media.class': 'Audio/Sink',
+                'node.description': strip.name,
+                'audio.position': list(strip.positions),
+                'node.link-group': strip.link_group,
+                'filter.smart': True,
+                'filter.smart.name': strip.link_group,
+                **({'filter.smart.target': {'node.name': host}} if host
+                   else {}),
+            },
+            'playback.props': {
+                'node.name': f'{strip.node_name}.out',
+                'node.description': f'{strip.name} output',
+                'node.passive': True,
+                'audio.position': list(strip.positions),
+                'node.link-group': strip.link_group,
+            },
+        },
+    })
+
+    for i, dest in enumerate(d for d in dests if d != host):
+        modules.append({
+            'name': 'libpipewire-module-filter-chain',
+            'args': {
+                'node.description': f'{strip.name} band {i + 1}',
+                'filter.graph': build_dest_graph(strip, dest),
+                'capture.props': {
+                    'node.name': f'{strip.node_name}.t{i}',
+                    'node.description': f'{strip.name} → {dest}',
+                    'audio.position': list(strip.positions),
+                    'stream.capture.sink': True,
+                    'target.object': strip.node_name,
+                    'node.dont-reconnect': False,
+                },
+                'playback.props': {
+                    'node.name': f'{strip.node_name}.t{i}.out',
+                    'node.description': f'{strip.name} → {dest}',
+                    'audio.position': list(strip.positions),
+                    'target.object': dest,
+                    'node.dont-reconnect': False,
+                },
+            },
+        })
+    return _base(modules)
+
+
 def _conf(strip: Strip, strips=None) -> dict:
+    if strip.role == 'xover':
+        return _xover_conf(strip)
     capture = {
         'node.name': strip.node_name,
-        'media.class': 'Audio/Sink',
         'node.description': strip.name,
         'audio.position': list(strip.positions),
     }
@@ -410,12 +854,44 @@ def _conf(strip: Strip, strips=None) -> dict:
         'node.name': f'{strip.node_name}.out',
         'node.description': f'{strip.name} output',
         'node.passive': True,
-        'audio.position': list(strip.positions),
+        'audio.position': strip.out_layout,
     }
-    target = resolve_target(strip, strips)
-    if target:
-        playback['target.object'] = target
-        playback['node.dont-reconnect'] = False
+
+    if strip.mode == 'tap':
+        # Not a sink at all: a capture stream reading what another strip is
+        # being fed, and a playback stream carrying it to its own device.
+        # `node.passive` would let it be suspended along with a target that
+        # is idle, which is wrong here — this stream is the reason the target
+        # has anything to play.
+        capture['stream.capture.sink'] = True
+        if strip.tap_source:
+            capture['target.object'] = strip.tap_source
+            capture['node.dont-reconnect'] = False
+        playback.pop('node.passive', None)
+        dest = strip.insert_device()
+        if dest:
+            playback['target.object'] = dest
+            playback['node.dont-reconnect'] = False
+    elif strip.mode == 'insert':
+        # A sink, but one WirePlumber splices into the device's path instead
+        # of offering as an output.  No `target.object` on the playback side:
+        # the session manager links it to whatever the filter attached to,
+        # and hard-wiring it would fight that.
+        capture['media.class'] = 'Audio/Sink'
+        capture['node.link-group'] = strip.link_group
+        capture['filter.smart'] = True
+        capture['filter.smart.name'] = strip.link_group
+        dest = strip.insert_device()
+        if dest:
+            capture['filter.smart.target'] = {'node.name': dest}
+        playback['node.link-group'] = strip.link_group
+    else:
+        capture['media.class'] = 'Audio/Sink'
+        target = resolve_target(strip, strips)
+        if target:
+            playback['target.object'] = target
+            playback['node.dont-reconnect'] = False
+
     args = {
         'node.description': strip.name,
         'filter.graph': build_graph(strip),
@@ -448,7 +924,10 @@ def _fan_members(strip: Strip, strips=None) -> list[str]:
 
 def sync_fan(strip: Strip, strips=None) -> tuple[bool, str]:
     """Create, update or remove the combine device this strip fans out to."""
-    members = _fan_members(strip, strips)
+    # Only a published sink ever fans out: the other two modes are defined by
+    # having exactly one destination, and a combine device is a new output in
+    # the user's list — the thing insert mode exists to avoid.
+    members = [] if strip.mode != 'sink' else _fan_members(strip, strips)
     existing = next((d for d in virtual.list_devices()
                      if d.id == strip.fan_id), None)
     if len(members) < 2:
@@ -458,13 +937,13 @@ def sync_fan(strip: Strip, strips=None) -> tuple[bool, str]:
     if existing:
         dev = existing
         dev.members = members
-        dev.positions = list(strip.positions)
+        dev.positions = strip.out_layout
         dev.enabled = strip.enabled
     else:
         dev = virtual.VirtualDevice(
             id=strip.fan_id, name=f'{strip.name} fan-out',
             kind='combine-sink', members=members,
-            positions=list(strip.positions), enabled=strip.enabled,
+            positions=strip.out_layout, enabled=strip.enabled,
             persistent=strip.persistent)
     return virtual.apply(dev)
 
@@ -473,6 +952,11 @@ def sync_fan(strip: Strip, strips=None) -> tuple[bool, str]:
 
 def apply(strip: Strip, strips=None) -> tuple[bool, str]:
     """Regenerate config and (re)start/stop the unit to match `enabled`."""
+    # An inserted strip that has since grown a second output, or gained a
+    # source sending into it, no longer fits the mode.  Fall back rather than
+    # write a config that would attach to a device and then be fed twice.
+    if strip.mode == 'insert' and not insertable(strip, strips):
+        strip.mode = 'sink'
     try:
         generate(strip, strips)
     except (spa_json.SpaJsonError, ValueError) as e:
@@ -543,7 +1027,9 @@ def output_targets(strip: Strip, sinks: list, edges: dict | None = None) -> list
 
 
 __all__ = [
-    'Strip', 'ROLES', 'SOURCE_KINDS', 'STAGE_KINDS', 'BAND_FILTERS',
+    'Strip', 'ROLES', 'MODES', 'insertable', 'SOURCE_KINDS', 'STAGE_KINDS',
+    'BAND_FILTERS',
+    'XOVER_MODES', 'XOVER_SLOPES', 'DEFAULT_SLOPE',
     'PATH_DIR', 'list_strips', 'sources', 'mixes', 'save_meta', 'new_strip',
     'new_stage', 'clone_stage', 'build_graph', 'generate', 'resolve_target',
     'sync_fan', 'apply', 'set_enabled', 'status', 'delete', 'target_edges',

--- a/pwctl/backend/pw.py
+++ b/pwctl/backend/pw.py
@@ -35,6 +35,27 @@ def set_setting(key: str, value) -> bool:
     return rc == 0
 
 
+_SMART_FILTERS = None
+
+
+def smart_filters_supported(refresh: bool = False) -> bool:
+    """Whether WirePlumber understands `filter.smart` (0.5 and later).
+
+    Probed rather than parsed out of a version string: WirePlumber 0.5 ships a
+    `filters` metadata object unconditionally — three of its linking scripts
+    require it — so the object is there even when no smart filter is running,
+    and it is absent on 0.4.  0.4 does read `node.link-group`, so a strip built
+    for an insert still pairs up there; it just never attaches to its target,
+    which makes it a silent no-op rather than a visible failure.  Worth one
+    probe to avoid offering the mode at all.
+    """
+    global _SMART_FILTERS
+    if _SMART_FILTERS is None or refresh:
+        rc, out, _ = run(['pw-metadata', '-n', 'filters'])
+        _SMART_FILTERS = rc == 0 and 'metadata' in out
+    return _SMART_FILTERS
+
+
 def read_default_names() -> dict:
     """Default sink/source node names from the `default` metadata."""
     rc, out, _ = run(['pw-metadata', '-n', 'default'])

--- a/pwctl/backend/pw.py
+++ b/pwctl/backend/pw.py
@@ -83,6 +83,18 @@ class AudioNode:
         # Filter-chain / loopback nodes have no device.api
         return 'device.api' not in self.props
 
+    @property
+    def is_insert(self):
+        """A smart filter: a sink only so that audio can pass through it.
+
+        The session manager splices it into a device's path and never offers
+        it as an output, so it must not appear anywhere the user is choosing
+        an endpoint.  It still has to be *findable* — Signal Paths reads its
+        volume and its level meter — which is why this is a flag rather than
+        an omission from the list.
+        """
+        return str(self.props.get('filter.smart', '')).lower() in ('true', '1')
+
 
 def _device_routes(dump) -> dict:
     """device object id -> (EnumRoute list, active Route list)."""
@@ -119,7 +131,14 @@ def _attach_ports(node: AudioNode, routes: dict):
                              and r.get('direction') == want), None)
 
 
-def list_audio_nodes(dump=None) -> list[AudioNode]:
+def list_audio_nodes(dump=None, inserts: bool = False) -> list[AudioNode]:
+    """Every audio endpoint.
+
+    Smart-filter inserts are left out unless `inserts` is set: they are sinks
+    only so that audio can pass through them, and every page that lists
+    endpoints is asking "what can the user pick?".  Signal Paths asks for
+    them because it draws the strips themselves.
+    """
     dump = dump if dump is not None else pw_dump()
     defaults = read_default_names()
     def_sink = defaults.get('default.audio.sink')
@@ -141,6 +160,8 @@ def list_audio_nodes(dump=None) -> list[AudioNode]:
             serial=props.get('object.serial', -1),
             is_default=(name == def_sink if mclass == 'Audio/Sink'
                         else name == def_source))
+        if node.is_insert and not inserts:
+            continue
         _attach_ports(node, routes)
         vol = get_volume(node.id)
         if vol:

--- a/pwctl/style.css
+++ b/pwctl/style.css
@@ -454,6 +454,20 @@ button.path-stage.k-convolver image {
     color: mix(@orange_3, @window_fg_color, 0.3);
 }
 
+button.path-stage.k-xover image {
+    color: mix(@green_4, @window_fg_color, 0.3);
+}
+
+/* A band row: the range on the left, the destinations on the right, and the
+   arrow between them carrying the whole meaning of the object. */
+box.path-band {
+    padding: 4px 2px;
+}
+
+box.path-band > image {
+    color: alpha(@window_fg_color, 0.35);
+}
+
 /* Bypassed: still legible, clearly out of the signal. Only the label and its
    icon are dimmed — dimming the whole chip would make it read as disabled
    rather than switched out. */

--- a/pwctl/ui/paths_page.py
+++ b/pwctl/ui/paths_page.py
@@ -66,8 +66,13 @@ STAGE_ICON = {
     'eq': 'audio-x-generic-symbolic',
     'effect': 'applications-multimedia-symbolic',
     'convolver': 'audio-headphones-symbolic',
+    'xover': 'view-list-symbolic',
 }
 BAND_TYPES = [('PK', 'Peak'), ('LSC', 'Low shelf'), ('HSC', 'High shelf')]
+XOVER_MODES = [('lowpass', 'Low band'), ('highpass', 'High band'),
+               ('bandpass', 'Middle band')]
+XOVER_SLOPES = [(12, '12 dB/oct (LR2)'), (24, '24 dB/oct (LR4)'),
+                (48, '48 dB/oct (LR8)')]
 
 # Rewriting the graph restarts the unit, so audio stops for an instant.  A
 # short delay after the last edit turns "bypass three stages" into one
@@ -697,6 +702,8 @@ class StageDialog(Adw.Window):
             g.add(self.plug_row)
             self._refresh_plugin_row()
             return g
+        if kind == 'xover':
+            return self._xover_group(p)
         if kind == 'convolver':
             g = group('Impulse response',
                       'A WAV or SOFA file. Convolution is the most expensive '
@@ -714,6 +721,124 @@ class StageDialog(Adw.Window):
             self._refresh_ir_row()
             return g
         return None
+
+    # -- crossover --------------------------------------------------------
+    # A band is two decisions, so it is two groups: what it keeps, and where
+    # it goes.  The second one is what makes this more than an equalizer —
+    # a band can leave on lanes the audio did not come in on, which is how
+    # one strip feeds a subwoofer and a pair of satellites at once.
+
+    def _xover_group(self, p):
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18)
+
+        g = group('Band', 'Linkwitz-Riley filters: two bands crossing at the '
+                          'same frequency add back up to a flat response.')
+        self.mode_row = Adw.ComboRow(
+            title='Keep', model=Gtk.StringList.new([m[1] for m in XOVER_MODES]))
+        self.mode_row.set_selected(next(
+            (i for i, m in enumerate(XOVER_MODES)
+             if m[0] == (p.get('mode') or 'lowpass')), 0))
+        g.add(self.mode_row)
+
+        self.freq_row = Adw.SpinRow(
+            title='Crossover (Hz)',
+            adjustment=_adj(20, 20000, float(p.get('freq') or 80.0), 10, 100),
+            digits=0)
+        g.add(self.freq_row)
+        self.freq_hi_row = Adw.SpinRow(
+            title='Upper crossover (Hz)',
+            subtitle='The top of the band.',
+            adjustment=_adj(20, 20000, float(p.get('freq_hi') or 2000.0),
+                            10, 100), digits=0)
+        g.add(self.freq_hi_row)
+
+        self.slope_row = Adw.ComboRow(
+            title='Slope',
+            subtitle='How sharply the band stops. Steeper keeps the bands out '
+                     'of each other’s way; gentler sounds more natural through '
+                     'the crossover.',
+            model=Gtk.StringList.new([s[1] for s in XOVER_SLOPES]))
+        self.slope_row.set_selected(next(
+            (i for i, s in enumerate(XOVER_SLOPES)
+             if s[0] == int(p.get('slope') or paths.DEFAULT_SLOPE)), 1))
+        g.add(self.slope_row)
+        box.append(g)
+
+        a = group('Alignment', 'Drivers are rarely the same distance away or '
+                               'wired the same way round — this is where that '
+                               'is corrected.')
+        self.xgain_row = Adw.SpinRow(
+            title='Level (dB)',
+            adjustment=_adj(-24, 12, float(p.get('gain') or 0.0), 0.5, 3),
+            digits=1)
+        a.add(self.xgain_row)
+        self.xdelay_row = Adw.SpinRow(
+            title='Delay (ms)',
+            subtitle='1 ms ≈ 34 cm. Delay the closer driver, not the far one.',
+            adjustment=_adj(0, paths.MAX_DELAY_S * 1000,
+                            float(p.get('delay') or 0.0), 0.1, 1), digits=2)
+        a.add(self.xdelay_row)
+        self.xinvert_row = Adw.SwitchRow(
+            title='Invert polarity',
+            subtitle='Flips this band over. Try it if the crossover region '
+                     'sounds hollow.')
+        self.xinvert_row.set_active(bool(p.get('invert')))
+        a.add(self.xinvert_row)
+        box.append(a)
+
+        layout = self.strip.out_layout
+        c = group('Channels',
+                  'Which lanes this band listens to, and which lanes it comes '
+                  'out on. Sending it somewhere else leaves the lanes it came '
+                  'from carrying the full range, so another band can take '
+                  'them. To gain lanes the strip hasn’t got, widen its output '
+                  'layout from the card menu.')
+        self.read_chips = self._lane_chips(
+            c, 'Listens to', layout, p.get('channels') or [])
+        self.route_chips = self._lane_chips(
+            c, 'Comes out on', layout, p.get('route') or [])
+        box.append(c)
+
+        def retitle(*_a):
+            mode = XOVER_MODES[self.mode_row.get_selected()][0]
+            self.freq_hi_row.set_visible(mode == 'bandpass')
+            self.freq_row.set_title(
+                'Lower crossover (Hz)' if mode == 'bandpass'
+                else 'Crossover (Hz)')
+            self.freq_row.set_subtitle(
+                {'lowpass': 'Everything above this is cut.',
+                 'highpass': 'Everything below this is cut.',
+                 'bandpass': 'The bottom of the band.'}[mode])
+        self.mode_row.connect('notify::selected', retitle)
+        retitle()
+        return box
+
+    def _lane_chips(self, grp, title, layout, chosen):
+        """A row of channel toggles; nothing ticked means "all of them"."""
+        from ..backend.surround import SPEAKER_NAMES
+        row = Adw.ActionRow(title=title, subtitle='')
+        wrap = Adw.WrapBox(child_spacing=6, line_spacing=6,
+                           valign=Gtk.Align.CENTER, margin_top=8,
+                           margin_bottom=8)
+        chips = {}
+        for pos in layout:
+            b = chip(pos, SPEAKER_NAMES.get(pos, pos), None,
+                     active=pos in chosen, toggle=True)
+            chips[pos] = b
+            wrap.append(b)
+
+        def note(*_a):
+            on = [p for p, b in chips.items() if b.get_active()]
+            row.set_subtitle('Every channel' if not on else ' · '.join(on))
+        for b in chips.values():
+            b.connect('toggled', note)
+        note()
+        row.add_suffix(wrap)
+        grp.add(row)
+        return chips
+
+    def _collect_lanes(self, chips):
+        return [p for p, b in chips.items() if b.get_active()]
 
     # -- eq bands ---------------------------------------------------------
     def _add_band(self, band=None):
@@ -850,6 +975,22 @@ class StageDialog(Adw.Window):
         if kind == 'eq':
             p['preamp'] = round(self.preamp.get_value(), 2)
             p['bands'] = self._collect_bands()
+        elif kind == 'xover':
+            mode = XOVER_MODES[self.mode_row.get_selected()][0]
+            freq = round(self.freq_row.get_value(), 1)
+            freq_hi = round(self.freq_hi_row.get_value(), 1)
+            if mode == 'bandpass' and freq_hi <= freq:
+                self.window.toast('The upper crossover has to sit above the '
+                                  'lower one')
+                return
+            p.update({
+                'mode': mode, 'freq': freq, 'freq_hi': freq_hi,
+                'slope': XOVER_SLOPES[self.slope_row.get_selected()][0],
+                'gain': round(self.xgain_row.get_value(), 2),
+                'delay': round(self.xdelay_row.get_value(), 3),
+                'invert': self.xinvert_row.get_active(),
+                'channels': self._collect_lanes(self.read_chips),
+                'route': self._collect_lanes(self.route_chips)})
         elif kind == 'convolver':
             p['gain'] = round(self.gain_row.get_value(), 3)
             if not p.get('filename'):
@@ -911,6 +1052,13 @@ class PathsPage:
         add_mix.set_child(Adw.ButtonContent(icon_name='list-add-symbolic',
                                             label='Mix', can_shrink=True))
         add_mix.connect('clicked', lambda *_: self._new_strip('mix'))
+        add_xov = Gtk.Button(
+            tooltip_text='A crossover splits the audio by frequency and '
+                         'sends each band to its own destination')
+        add_xov.set_child(Adw.ButtonContent(icon_name='view-list-symbolic',
+                                            label='Crossover',
+                                            can_shrink=True))
+        add_xov.connect('clicked', lambda *_: self._new_xover())
         # Its own colour, because it does something of a different order from
         # the two beside it: those add an empty strip, this one arrives with a
         # chain already in it.
@@ -931,6 +1079,7 @@ class PathsPage:
         toolbar = Gtk.Box(spacing=8, css_classes=['path-toolbar'])
         toolbar.append(self.summary)
         toolbar.append(tpl)
+        toolbar.append(add_xov)
         toolbar.append(add_mix)
         toolbar.append(add_src)
         toolbar.append(more)
@@ -962,8 +1111,16 @@ class PathsPage:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18,
                       margin_top=18, margin_bottom=36,
                       margin_start=16, margin_end=16)
+        # Crossovers sit above the two columns, full width, because that is
+        # what they are: not a source and not a mix, but the thing in between
+        # that takes what plays and hands each band of it to a destination.
+        # They connect to devices rather than to strips, so drawing them as a
+        # third column with no wires reaching it would say the wrong thing.
+        self.xover_body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
+                                  spacing=12)
         box.append(toolbar)
         box.append(self.quick)
+        box.append(self.xover_body)
         box.append(self.board)
         # 1600 let each column grow past 700px on a wide screen, which a card
         # has nothing to do with: the name sits in the first third and the
@@ -1047,6 +1204,10 @@ class PathsPage:
         ('camera-video-symbolic', 'Speakers and a stream mix',
          'One chain into your speakers, a second into a virtual output that '
          'OBS or Discord can capture.', '_quick_stream'),
+        ('view-list-symbolic', 'Subwoofer and satellites',
+         'A crossover: the low band goes to one output, everything above it '
+         'to another. Your output stays what it is — nothing new to select.',
+         '_quick_crossover'),
         ('audio-headphones-symbolic', 'Headphones and speakers',
          'A speaker mix carrying the audio and a headphone mix with its own '
          'tilt waiting beside it. Switch with one click.',
@@ -1194,7 +1355,9 @@ class PathsPage:
 
         def collect():
             dump = pw.pw_dump()
-            nodes = pw.list_audio_nodes(dump)
+            # Inserts included: this page draws the strips themselves, and an
+            # inserted strip still has a volume and a level meter to show.
+            nodes = pw.list_audio_nodes(dump, inserts=True)
             streams = [s for s in pw.list_streams(dump) if s.is_playback
                        and not s.props.get('node.name', '').startswith('pwctl.')]
             strips = paths.list_strips()
@@ -1212,7 +1375,12 @@ class PathsPage:
         """
         return (
             tuple((s.id, s.role, s.order, s.name, s.kind, s.enabled,
-                   s.channels, tuple(s.sends), tuple(s.outputs),
+                   s.channels, s.out_channels, tuple(s.sends),
+                   tuple(s.outputs), s.mode, s.insert_into,
+                   tuple((b.get('id'), b.get('name'), b.get('lo'),
+                          b.get('hi'), b.get('mute'), tuple(b.get('outputs')
+                                                            or ()))
+                         for b in s.bands),
                    tuple((st.get('id'), st.get('name'), st.get('kind'),
                           bool(st.get('bypass'))) for st in s.stages))
                   for s in self._strips),
@@ -1250,7 +1418,7 @@ class PathsPage:
         self._cards = {}
         self._chips = {}
         self._rails = {}
-        for body in (self.src_body, self.mix_body):
+        for body in (self.src_body, self.mix_body, self.xover_body):
             child = body.get_first_child()
             while child is not None:
                 nxt = child.get_next_sibling()
@@ -1259,6 +1427,11 @@ class PathsPage:
 
         srcs = paths.sources(self._strips)
         mixes = paths.mixes(self._strips)
+        xovers = paths.crossovers(self._strips)
+        for x in xovers:
+            card = self._xover_card(x)
+            self._cards[x.id] = card
+            self.xover_body.append(card)
         empty = not self._strips
         self.quick.set_visible(empty)
         self.board.set_visible(not empty)
@@ -1464,10 +1637,18 @@ class PathsPage:
                           css_classes=['heading'],
                           ellipsize=Pango.EllipsizeMode.END)
         line.append(title)
-        tag = Gtk.Label(label=_layout_name(strip.channels),
-                        css_classes=['path-tag'], valign=Gtk.Align.CENTER)
-        tag.set_tooltip_text(f'{strip.channels} channels: '
-                             + ' '.join(strip.positions))
+        # A split strip carries two layouts, and which one it comes out as is
+        # the more surprising of the two, so both are on the tag.
+        split = strip.out_channels != strip.channels
+        tag = Gtk.Label(
+            label=(f'{_layout_name(strip.channels)} → '
+                   f'{_layout_name(strip.out_channels)}') if split
+            else _layout_name(strip.channels),
+            css_classes=['path-tag'], valign=Gtk.Align.CENTER)
+        tag.set_tooltip_text(
+            f'In: {" ".join(strip.positions)}\n'
+            f'Out: {" ".join(strip.out_layout)}' if split
+            else f'{strip.channels} channels: ' + ' '.join(strip.positions))
         line.append(tag)
         if strip.enabled and state == 'failed':
             line.append(pill('failed', state_style(state)))
@@ -1523,6 +1704,10 @@ class PathsPage:
              lambda s=strip: self._rename(s)),
             ('media-playlist-repeat-symbolic', 'Channel layout…',
              lambda s=strip: self._pick_layout(s)),
+            ('object-flip-horizontal-symbolic', 'Output layout…',
+             lambda s=strip: self._pick_out_layout(s)),
+            ('insert-link-symbolic', 'How it connects…',
+             lambda s=strip: self._pick_mode(s)),
             None,
             ('edit-copy-symbolic', 'Duplicate',
              lambda s=strip: self._duplicate(s)),
@@ -1540,10 +1725,282 @@ class PathsPage:
             base = KIND_BLURB.get(strip.kind, 'A source')
             return f'{base} → {dest}' if dest \
                 else f'{base} → the default output'
+        # An inserted mix has no feeder and never will: it sits inside the
+        # device's own path.  Saying "nothing feeds this" would read as a
+        # fault, so each mode states what it is instead.
+        if strip.mode == 'insert':
+            dev = strip.insert_device()
+            return ('Inside ' + self._device_label(dev)) if dev \
+                else 'Inside the default output'
+        if strip.mode == 'tap':
+            src = next((s.name for s in self._strips
+                        if s.node_name == strip.tap_source), '')
+            dev = strip.insert_device()
+            out = self._device_label(dev) if dev else 'the default output'
+            return f'Copy of {src} → {out}' if src else f'A copy → {out}'
         feeders = [s.name for s in paths.sources(self._strips)
                    if strip.id in s.sends]
         return ('Fed by ' + ', '.join(feeders)) if feeders \
             else 'Nothing feeds this yet'
+
+    # ------------------------------------------------------ crossover card --
+    # One card, one table: a row per band, each row saying what it keeps and
+    # where that goes.  The whole point of the object is that those two facts
+    # sit side by side and can be changed independently, so the card refuses
+    # to hide either of them behind a dialog.
+
+    def _xover_card(self, strip):
+        state = self._states.get(strip.id, 'inactive')
+        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10,
+                       css_classes=['path-card', 'k-xover'])
+
+        head = Gtk.Box(spacing=10)
+        head.append(avatar('view-list-symbolic', 'xover'))
+        names = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=1,
+                        hexpand=True, valign=Gtk.Align.CENTER)
+        line = Gtk.Box(spacing=6)
+        line.append(Gtk.Label(label=esc(strip.name), xalign=0,
+                              css_classes=['heading']))
+        line.append(Gtk.Label(label=f'{len(strip.bands)} bands',
+                              css_classes=['path-tag'],
+                              valign=Gtk.Align.CENTER))
+        if strip.enabled and state == 'failed':
+            line.append(pill('failed', state_style(state)))
+        names.append(line)
+        dev = strip.insert_into
+        names.append(Gtk.Label(
+            label=esc('In front of ' + (self._device_label(dev) if dev
+                                        else 'the default output')),
+            xalign=0, css_classes=['dim-label', 'caption'],
+            ellipsize=Pango.EllipsizeMode.END))
+        head.append(names)
+
+        dot = Gtk.Box(css_classes=['path-dot'], valign=Gtk.Align.CENTER)
+        if strip.enabled and state == 'active':
+            dot.add_css_class('on')
+        elif strip.enabled and state == 'failed':
+            dot.add_css_class('err')
+        elif strip.enabled:
+            dot.add_css_class('busy')
+        head.append(dot)
+        sw = Gtk.Switch(active=strip.enabled, valign=Gtk.Align.CENTER,
+                        tooltip_text='Turn this crossover on or off')
+        sw.connect('state-set', self._toggle, strip)
+        head.append(sw)
+        more = Gtk.MenuButton(icon_name='view-more-symbolic',
+                              css_classes=['flat'], valign=Gtk.Align.CENTER)
+        more.set_popover(menu_popover([
+            ('document-edit-symbolic', 'Rename…',
+             lambda s=strip: self._rename(s)),
+            ('audio-speakers-symbolic', 'Sits in front of…',
+             lambda s=strip: self._pick_insert_into(s)),
+            None,
+            ('user-trash-symbolic', 'Delete',
+             lambda s=strip: self._delete(s), 'destructive-flat'),
+        ]))
+        head.append(more)
+        card.append(head)
+
+        for band in strip.bands:
+            card.append(self._band_row(strip, band))
+
+        add = Gtk.Button(css_classes=['flat', 'path-ghost'])
+        inner = Gtk.Box(spacing=8, halign=Gtk.Align.CENTER)
+        inner.append(Gtk.Image.new_from_icon_name('list-add-symbolic'))
+        inner.append(Gtk.Label(label='Add a band'))
+        add.set_child(inner)
+        add.connect('clicked', lambda *_: self._add_band_row(strip))
+        card.append(add)
+        return card
+
+    def _band_row(self, strip, band):
+        row = Gtk.Box(spacing=8, css_classes=['path-band'])
+
+        edit = Gtk.Button(css_classes=['path-stage', 'k-xover'],
+                          valign=Gtk.Align.CENTER,
+                          tooltip_text='Change what this band keeps')
+        inner = Gtk.Box(spacing=6)
+        inner.append(Gtk.Image.new_from_icon_name('view-list-symbolic'))
+        text = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=1)
+        text.append(Gtk.Label(label=esc(band.get('name') or 'Band'), xalign=0))
+        text.append(Gtk.Label(label=paths.band_label(band), xalign=0,
+                              css_classes=['dim-label', 'caption']))
+        inner.append(text)
+        edit.set_child(inner)
+        if band.get('mute'):
+            edit.add_css_class('path-stage-off')
+        edit.connect('clicked', lambda *_: self._edit_band(strip, band))
+        row.append(edit)
+
+        row.append(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+
+        chips = []
+        for dev in band.get('outputs') or []:
+            chips.append(chip(self._device_label(dev),
+                              'Stop sending this band here',
+                              lambda _b, s=strip, bd=band, d=dev:
+                              self._drop_band_dest(s, bd, d),
+                              icon='window-close-symbolic', active=True))
+        chips.append(chip('Add a destination', 'Where this band is played',
+                          lambda _b, s=strip, bd=band:
+                          self._add_band_dest(s, bd),
+                          icon='list-add-symbolic'))
+        wrap = Adw.WrapBox(child_spacing=6, line_spacing=6, hexpand=True,
+                           valign=Gtk.Align.CENTER)
+        for c in chips:
+            wrap.append(c)
+        row.append(wrap)
+
+        rm = icon_button('user-trash-symbolic', 'Remove this band',
+                         lambda *_: self._drop_band(strip, band))
+        rm.set_valign(Gtk.Align.CENTER)
+        row.append(rm)
+        return row
+
+    # -- crossover editing -------------------------------------------------
+    def _new_xover(self):
+        def make(name):
+            if not name:
+                return
+            dev = self._default_sink_name()
+            x = paths.new_strip(name, 'xover', insert_into=dev)
+            x.enabled = False
+            paths.save_meta(x)
+            self.refresh()
+            self.window.toast(f'“{name}” added — give each band a destination, '
+                              'then turn it on')
+        prompt_text(self.window, 'New crossover',
+                    'It sits in front of an output and hands each band of the '
+                    'audio to a destination of your choosing.',
+                    'Crossover', make, action='Add')
+
+    def _add_band_row(self, strip):
+        # A new band starts where the last one ended, so adding rows walks up
+        # the spectrum instead of stacking bands on top of each other.
+        top = max([float(b.get('hi') or 0) for b in strip.bands] or [0.0])
+        edge = max([float(b.get('lo') or 0) for b in strip.bands] + [top])
+        strip.bands = [*strip.bands,
+                       paths.new_band(f'Band {len(strip.bands) + 1}',
+                                      lo=edge or 80.0)]
+        self._save_and_apply(strip)
+
+    def _drop_band(self, strip, band):
+        strip.bands = [b for b in strip.bands if b['id'] != band['id']]
+        self._save_and_apply(strip)
+
+    def _drop_band_dest(self, strip, band, dev):
+        band['outputs'] = [d for d in band.get('outputs') or [] if d != dev]
+        self._save_and_apply(strip)
+
+    def _add_band_dest(self, strip, band):
+        taken = set(band.get('outputs') or [])
+        items = [(n.name, n.description, n.name) for n in self._nodes
+                 if n.is_sink and n.name not in taken
+                 and not n.name.startswith('pwctl.')]
+
+        def picked(dev):
+            band['outputs'] = [*(band.get('outputs') or []), dev]
+            self._save_and_apply(strip)
+        search_picker(self.window, f"Where does “{band.get('name')}” play?",
+                      'The band is sent here. Give a band several '
+                      'destinations and it plays on all of them; give two '
+                      'bands the same one and they are summed.',
+                      items, picked, empty='No output devices found')
+
+    def _pick_insert_into(self, strip):
+        """The output the crossover stands in front of.
+
+        Everything heading for that device goes through the crossover first,
+        which is what makes it intermediate: the device stays the output apps
+        play to, and the bands decide where the audio actually ends up.
+        """
+        items = [('', 'The default output',
+                  'Follows whatever output is current')]
+        items += [(n.name, n.description, n.name) for n in self._nodes
+                  if n.is_sink and not n.name.startswith('pwctl.')]
+
+        def picked(dev):
+            strip.insert_into = dev
+            self._save_and_apply(strip)
+        search_picker(self.window, 'Sits in front of',
+                      'Audio on its way to this output is split by the '
+                      'crossover before it gets there.', items, picked)
+
+    def _edit_band(self, strip, band):
+        dlg = Adw.Window(title=band.get('name') or 'Band',
+                         transient_for=self.window, modal=True,
+                         default_width=520, default_height=620)
+        g = group('Band', 'Leave an edge at 0 for "no limit on that side": '
+                          '0 to 80 is a subwoofer band, 80 to 0 is everything '
+                          'above it.')
+        name = Adw.EntryRow(title='Name')
+        name.set_text(band.get('name') or '')
+        g.add(name)
+        lo = Adw.SpinRow(title='From (Hz)', subtitle='0 = no lower limit',
+                         adjustment=_adj(0, 20000, float(band.get('lo') or 0),
+                                         10, 100), digits=0)
+        hi = Adw.SpinRow(title='To (Hz)', subtitle='0 = no upper limit',
+                         adjustment=_adj(0, 20000, float(band.get('hi') or 0),
+                                         10, 100), digits=0)
+        g.add(lo)
+        g.add(hi)
+        slope = Adw.ComboRow(
+            title='Slope', subtitle='How sharply the band stops.',
+            model=Gtk.StringList.new([s[1] for s in XOVER_SLOPES]))
+        slope.set_selected(next((i for i, s in enumerate(XOVER_SLOPES)
+                                 if s[0] == int(band.get('slope') or 24)), 1))
+        g.add(slope)
+
+        a = group('Alignment', 'Drivers are rarely the same distance away or '
+                               'wired the same way round.')
+        gain = Adw.SpinRow(title='Level (dB)',
+                           adjustment=_adj(-24, 12, float(band.get('gain') or 0),
+                                           0.5, 3), digits=1)
+        delay = Adw.SpinRow(
+            title='Delay (ms)', subtitle='1 ms ≈ 34 cm.',
+            adjustment=_adj(0, paths.MAX_DELAY_S * 1000,
+                            float(band.get('delay') or 0), 0.1, 1), digits=2)
+        invert = Adw.SwitchRow(title='Invert polarity')
+        invert.set_active(bool(band.get('invert')))
+        mute = Adw.SwitchRow(title='Mute this band',
+                             subtitle='Keeps the row, takes it out of the '
+                                      'signal.')
+        mute.set_active(bool(band.get('mute')))
+        for r in (gain, delay, invert, mute):
+            a.add(r)
+
+        def save(_b):
+            lov, hiv = round(lo.get_value()), round(hi.get_value())
+            if lov and hiv and hiv <= lov:
+                self.window.toast('“To” has to sit above “From”')
+                return
+            band.update({'name': name.get_text().strip() or 'Band',
+                         'lo': float(lov), 'hi': float(hiv),
+                         'slope': XOVER_SLOPES[slope.get_selected()][0],
+                         'gain': round(gain.get_value(), 2),
+                         'delay': round(delay.get_value(), 3),
+                         'invert': invert.get_active(),
+                         'mute': mute.get_active()})
+            dlg.close()
+            self._save_and_apply(strip)
+
+        ok = Gtk.Button(label='Save', halign=Gtk.Align.END, margin_top=12,
+                        css_classes=['suggested-action', 'pill'])
+        ok.connect('clicked', save)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18,
+                      margin_top=12, margin_bottom=24,
+                      margin_start=18, margin_end=18)
+        box.append(g)
+        box.append(a)
+        box.append(ok)
+        sw = Gtk.ScrolledWindow(vexpand=True,
+                                hscrollbar_policy=Gtk.PolicyType.NEVER)
+        sw.set_child(Adw.Clamp(maximum_size=520, child=box))
+        view = Adw.ToolbarView()
+        view.add_top_bar(Adw.HeaderBar())
+        view.set_content(sw)
+        dlg.set_content(view)
+        dlg.present()
 
     # -- chain rail --------------------------------------------------------
     def _rail(self, strip):
@@ -1723,6 +2180,8 @@ class PathsPage:
                       margin_start=6, margin_end=6)
         for kind, label, sub in (
             ('eq', 'Equalizer', 'Bands you can move while it plays'),
+            ('xover', 'Crossover', 'Split the audio by frequency and send '
+                                   'each band its own way'),
             ('effect', 'Plugin', 'Any LADSPA or LV2 on this system'),
             ('convolver', 'Convolver', 'An impulse response file'),
         ):
@@ -2123,7 +2582,8 @@ class PathsPage:
 
     def _add_stage(self, strip, kind):
         stage = paths.new_stage(kind, {'eq': 'Equalizer', 'effect': 'Plugin',
-                                       'convolver': 'Convolver'}[kind])
+                                       'convolver': 'Convolver',
+                                       'xover': 'Crossover'}[kind])
         if kind == 'eq':
             stage['params'] = {'preamp': 0.0, 'bands': [
                 {'on': True, 'type': 'PK', 'freq': f, 'gain': 0.0, 'q': 1.0}
@@ -2197,6 +2657,66 @@ class PathsPage:
         search_picker(self.window, 'Channel layout',
                       'How many channels this strip carries. Every stage is '
                       'built across all of them.', items, picked)
+
+    def _pick_out_layout(self, strip):
+        """What comes out, when that is not what went in.
+
+        Only a crossover has a reason to change this: routing the low band to
+        lanes of its own needs lanes of its own to exist.  Everything else is
+        happier with the two layouts kept the same, which is why "same as the
+        input" sits at the top and is what every strip starts as.
+        """
+        from ..backend import surround
+        layouts = [('mono', 'Mono 1.0', ['FL'])] + list(surround.LAYOUTS)
+        items = [([], 'Same as the input', ' '.join(strip.positions))]
+        items += [(pos, label, ' '.join(pos)) for _k, label, pos in layouts]
+
+        def picked(positions):
+            positions = list(positions)
+            if positions == list(strip.positions):
+                positions = []          # not a split, just the same thing
+            if positions == list(strip.out_positions):
+                return
+            strip.out_positions = positions
+            self._save_and_apply(
+                strip, f'“{strip.name}” now comes out as '
+                f'{_layout_name(strip.out_channels)}')
+        search_picker(self.window, 'Output layout',
+                      'The channels leaving this strip. Widen it to give a '
+                      'crossover band somewhere of its own to go — a stereo '
+                      'strip coming out as 2.1 can put its low band on the '
+                      'subwoofer lane.', items, picked)
+
+    def _pick_mode(self, strip):
+        """Insert into a device, or publish an output of its own.
+
+        Inserting is the quiet option and the default: the device stays the
+        thing people select, and nothing new turns up in anyone's list.  A
+        strip only needs its own output when something has to *choose* it —
+        the capture sink OBS records from, or a mix fed by a source strip.
+        """
+        items = []
+        if paths.insertable(strip, self._strips) or strip.mode == 'insert':
+            dev = strip.insert_device()
+            items.append(('insert', 'Inside the output',
+                          'Nothing new appears — it corrects '
+                          + (self._device_label(dev) if dev
+                             else 'whatever the default output is')))
+        items.append(('sink', 'Its own output',
+                      'Publishes a device others can select and play into'))
+        if strip.mode == 'tap':
+            items.append(('tap', 'A copy of another strip',
+                          'Reads what another strip is fed, plays it '
+                          'elsewhere. Set up by the crossover recipe.'))
+
+        def picked(mode):
+            if mode == strip.mode:
+                return
+            strip.mode = mode
+            self._save_and_apply(strip)
+        search_picker(self.window, 'How it connects', 'Whether this strip '
+                      'becomes part of a device’s path or an output of its '
+                      'own.', items, picked)
 
     def _delete(self, strip):
         def go():
@@ -2429,15 +2949,82 @@ class PathsPage:
         async_call(build, done)
 
     def _quick_eq_all(self):
+        """One equalizer, inside the output that is already selected.
+
+        This used to be a source and a mix, which meant two new sinks and a
+        trip to the sound settings to pick one of them.  Inserted, it is the
+        same equalizer with nothing to choose: the device stays the output
+        and every app keeps playing to it.
+        """
         stage = paths.new_stage('eq', 'Equalizer')
         stage['params'] = {'preamp': 0.0, 'bands': [
             {'on': True, 'type': 'PK', 'freq': f, 'gain': 0.0, 'q': 1.0}
             for f in (60, 250, 1000, 4000, 12000)]}
-        self._quick_pair('Everything', 'Speakers', [stage],
-                         kind='everything')
+        dev = self._default_sink_name()
+        mix = paths.new_strip('Equalizer', 'mix', mode='insert',
+                              outputs=[dev] if dev else [], stages=[stage])
+        mix.enabled = True
+
+        def done(result, e):
+            ok, err = result if result else (False, str(e or ''))
+            self.window.toast('Equalizer added to your output — nothing to '
+                              'select' if ok
+                              else f'Failed: {err or "unknown error"}')
+            self.refresh()
+        async_call(lambda: paths.apply(mix, [mix]), done)
 
     def _quick_app_fx(self):
         self._quick_pair('App', 'Speakers', [], kind='app')
+
+    def _quick_crossover(self):
+        """Two mixes crossing at 80 Hz, one per output device.
+
+        The two bands are built as a matched pair — same frequency, same
+        slope, complementary filters — because that is the part that is easy
+        to get wrong by hand and the part that has to stay true afterwards:
+        move one and the crossover region either sags or doubles up.  Which
+        device carries the low band is the only thing that cannot be guessed,
+        so it is the only thing asked.
+        """
+        dev = self._default_sink_name()
+        items = [(n.name, n.description, n.name) for n in self._nodes
+                 if n.is_sink and not n.name.startswith('pwctl.')]
+
+        def picked(sub_dev):
+            # One crossover, two bands, one destination each.  It stands in
+            # front of the output that is already selected, so no app moves
+            # and nothing new turns up to be chosen.
+            x = paths.new_strip('Crossover', 'xover', insert_into=dev,
+                                bands=[paths.new_band('Low', hi=80.0,
+                                                      outputs=[sub_dev]),
+                                       paths.new_band('High', lo=80.0,
+                                                      outputs=[dev] if dev
+                                                      else [])])
+            x.enabled = True
+            made = [x]
+
+            def build():
+                for s in made:
+                    ok, err = paths.apply(s, made)
+                    if not ok:
+                        return ok, err
+                return True, ''
+
+            def done(result, e):
+                ok, err = result if result else (False, str(e or ''))
+                self.window.toast(
+                    'Crossing at 80 Hz — your output is unchanged, open '
+                    'either band to move it'
+                    if ok else f'Failed: {err or "unknown error"}')
+                self.refresh()
+            async_call(build, done)
+
+        search_picker(self.window, 'Which output carries the low band?',
+                      'Everything below 80 Hz goes there; everything above it '
+                      'goes to your current output. Both bands are ordinary '
+                      'stages afterwards — change the frequency, the slope or '
+                      'the alignment on either one.',
+                      items, picked, empty='No output devices found')
 
     def _quick_two_outputs(self):
         """Speakers now, headphones ready beside them.
@@ -2552,6 +3139,7 @@ class PathsPage:
             stages, missing = path_templates.build_stages(tpl, installed)
             strip = paths.new_strip(tpl.title, tpl.role, kind=tpl.kind,
                                     positions=list(tpl.positions),
+                                    out_positions=list(tpl.out_positions),
                                     stages=stages)
             strip.enabled = True
             made = [strip]


### PR DESCRIPTION
## Crossovers

A **crossover** is a new kind of object on the Signal Paths board. It sits
between what plays and what it comes out of. It stands in front of an output
and hands each band of that audio to destinations of its own choosing.

The card is a table. One row per band. Each row carries a frequency range and
the destinations that range plays on.

| band | goes to |
|---|---|
| 80 Hz and below | Internal audio |
| 80 Hz – 2 kHz | Focusrite Scarlett 2i2 |
| 2 kHz and above | Internal audio |

A band can name several destinations. Two bands can name the same one, and are
summed. Bands use Linkwitz-Riley sections at 12/24/48 dB/oct, so two bands
meeting at one frequency add back up flat. Each band carries its own level,
delay and polarity, because drivers are rarely the same distance away or wired
the same way round.

**Why an object and not a stage.** A stage can only filter the path it stands
in. Sending different frequencies to different destinations meant building the
path twice and keeping the two halves in step by hand.

## Strips insert instead of publishing

A strip used to publish a sink. Every equalizer and every crossover therefore
added entries to the sound settings, and asked the user to go and select one.
A strip now has a **mode**:

- **`insert`** — attaches to a device as a `filter.smart` insert. The session
  manager routes everything heading for that device through it first. The
  device stays the output everyone selects. No app is repointed. This is the
  new default.
- **`sink`** — the previous behaviour. It is still right for a bus something
  else has to *choose*, such as the capture sink OBS records from. A mix that a
  source strip sends to falls back to this on its own.
- **`tap`** — a capture stream, not a sink. It is how one band reaches a second
  card without an output being published to carry it.

A crossover generates **one unit** holding one filter-chain per destination.
The insert serves the device it sits in front of. Taps serve the rest. The
number of bands never shows up as a number of objects.

Inserts are hidden from the Devices page, the dashboard and every target
picker, since nobody can usefully select one. Signal Paths still sees them,
because it draws the strips themselves with their volume and level meter.

## Also here

For the single-card case, where the bands ride on different channels of one
output:

- a Crossover **stage** with per-channel routing;
- an **output layout**, so a stereo strip can come out as 2.1;
- a **Bass management** template.

## Verified against a live session

Two cards, an internal analogue output and a Focusrite Scarlett 2i2. The graph
is measured at the devices' own monitor ports, with a tone played to the
unchanged output.

Bands `0–80` and `2 k–∞` to the internal card, band `80–2 k` to the Focusrite:

| tone | internal card | Focusrite | expected |
|---|---|---|---|
| 40 Hz | **−41.6 dB** | −65.7 dB | internal |
| 500 Hz | −89.0 dB | **−41.1 dB** | Focusrite |
| 8 kHz | **−41.1 dB** | −93.8 dB | internal |

Each band lands on its assigned destination, with 24–53 dB of rejection on the
other. Two non-adjacent bands sum correctly on one card. The 24 dB figure at
one octave below the crossover matches LR4 theory.

`wpctl` lists two sinks while all of this runs: the two real cards. Nothing
else is published.

## Notes for review

- The merge with `main` kept **both** Unreleased changelog entries — this one
  and the App Policy entry.
- The version is **not** bumped. The changelog entry sits under `Unreleased`.
- There is **no screenshot** of the crossover card yet.
- The band dialog was checked by opening it and reading every field. The test
  values themselves were set through the backend, not by clicking.
